### PR TITLE
use 'default' for cloudwatch attributes

### DIFF
--- a/attributes/cfn-cloudwatch.rb
+++ b/attributes/cfn-cloudwatch.rb
@@ -1,4 +1,4 @@
-node['cfn']['cloudwatch'].tap do |config|
+default['cfn']['cloudwatch'].tap do |config|
   config['report_failure'] = true
   config['report_success'] = false
   config['report_cookbooks'] = true


### PR DESCRIPTION
Hi there,

When using the latest version of this cookbook I get the following error:

```
root@ip-10-0-163-178:~/chef# chef-client -z -c /root/chef/solo.rb -o 'role[base]'
Starting Chef Client, version 12.18.31
[2017-01-29T23:59:32+00:00] WARN: Run List override has been provided.
[2017-01-29T23:59:32+00:00] WARN: Original Run List: []
[2017-01-29T23:59:32+00:00] WARN: Overridden Run List: [role[base]]
resolving cookbooks for run list: ["myapp"]
Synchronizing Cookbooks:
  - myapp (0.1.0)
  - apt (2.7.0)
  - chef_cfn (2.1.1)
  - citadel (1.0.2)
  - git (5.0.2)
  - openssh (2.1.1)
  - sudo (2.6.0)
  - user (0.6.0)
  - chef_handler (2.1.0)
  - ohai (4.2.3)
  - python (1.4.6)
  - build-essential (7.0.3)
  - dmg (3.1.0)
  - yum-epel (2.1.1)
  - iptables (3.1.0)
  - compat_resource (12.16.3)
  - seven_zip (2.0.2)
  - mingw (1.2.5)
  - windows (2.1.1)
Installing Cookbook Gems:
Compiling Cookbooks...

================================================================================
Recipe Compile Error in /root/chef/local-mode-cache/cache/cookbooks/chef_cfn/attributes/cfn-cloudwatch.rb
================================================================================

NoMethodError
-------------
undefined method `[]=' for nil:NilClass

Cookbook Trace:
---------------
  /root/chef/local-mode-cache/cache/cookbooks/chef_cfn/attributes/cfn-cloudwatch.rb:2:in `block in from_file'
  /root/chef/local-mode-cache/cache/cookbooks/chef_cfn/attributes/cfn-cloudwatch.rb:1:in `tap'
  /root/chef/local-mode-cache/cache/cookbooks/chef_cfn/attributes/cfn-cloudwatch.rb:1:in `from_file'

Relevant File Content:
----------------------
/root/chef/local-mode-cache/cache/cookbooks/chef_cfn/attributes/cfn-cloudwatch.rb:

  1:  node['cfn']['cloudwatch'].tap do |config|
  2>>   config['report_failure'] = true
  3:    config['report_success'] = false
  4:    config['report_cookbooks'] = true
  5:  end
  6:  

Platform:
---------
x86_64-linux


Running handlers:
[2017-01-29T23:59:33+00:00] ERROR: Running exception handlers
Running handlers complete
[2017-01-29T23:59:33+00:00] ERROR: Exception handlers complete
Chef Client failed. 0 resources updated in 02 seconds
[2017-01-29T23:59:33+00:00] FATAL: Stacktrace dumped to /root/chef/local-mode-cache/cache/chef-stacktrace.out
[2017-01-29T23:59:33+00:00] FATAL: Please provide the contents of the stacktrace.out file if you file a bug report
[2017-01-29T23:59:33+00:00] ERROR: undefined method `[]=' for nil:NilClass
[2017-01-29T23:59:33+00:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```

The change to the ```cfn-cloudwatch.rb``` file shown below seems to fix the issue and also makes that attributes file follow the same format as the others.

Thanks, Dylan